### PR TITLE
Load plugin textdomain

### DIFF
--- a/rename-wp-login.php
+++ b/rename-wp-login.php
@@ -257,7 +257,9 @@ if ( defined( 'ABSPATH' ) && ! class_exists( 'Rename_WP_Login' ) ) {
 
 		public function plugins_loaded() {
 			global $pagenow;
-
+			
+			load_plugin_textdomain( 'rename-wp-login' );
+			
 			if (
 				! is_multisite() && (
 					strpos( $_SERVER['REQUEST_URI'], 'wp-signup' ) !== false ||

--- a/rename-wp-login.php
+++ b/rename-wp-login.php
@@ -247,9 +247,9 @@ if ( defined( 'ABSPATH' ) && ! class_exists( 'Rename_WP_Login' ) ) {
 
 		public function plugin_action_links( $links ) {
 			if ( is_network_admin() && is_plugin_active_for_network( $this->basename() ) ) {
-				array_unshift( $links, '<a href="' . network_admin_url( 'settings.php#rwl-page-input' ) . '">' . __( 'Settings' ) . '</a>' );
+				array_unshift( $links, '<a href="' . network_admin_url( 'settings.php#rwl-page-input' ) . '">' . __( 'Settings', 'rename-wp-login' ) . '</a>' );
 			} elseif ( ! is_network_admin() ) {
-				array_unshift( $links, '<a href="' . admin_url( 'options-permalink.php#rwl-page-input' ) . '">' . __( 'Settings' ) . '</a>' );
+				array_unshift( $links, '<a href="' . admin_url( 'options-permalink.php#rwl-page-input' ) . '">' . __( 'Settings', 'rename-wp-login' ) . '</a>' );
 			}
 
 			return $links;

--- a/rename-wp-login.php
+++ b/rename-wp-login.php
@@ -256,10 +256,11 @@ if ( defined( 'ABSPATH' ) && ! class_exists( 'Rename_WP_Login' ) ) {
 		}
 
 		public function plugins_loaded() {
-			global $pagenow;
-			
+			// Load translations
 			load_plugin_textdomain( 'rename-wp-login' );
-			
+
+			global $pagenow;
+
 			if (
 				! is_multisite() && (
 					strpos( $_SERVER['REQUEST_URI'], 'wp-signup' ) !== false ||


### PR DESCRIPTION
In order to update the string translations, a call to `load_plugin_textdomain()` is needed.
See https://wordpress.slack.com/archives/meta-language-packs/p1452447741044692