### PR TITLE
Fix Authors section is case sensitive

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Rename wp-login.php ===
 
-Contributors:      iseulde, IvanRF
+Contributors:      iseulde, ivanrf
 Tags:              rename, login, wp-login, wp-login.php, custom login url
 Requires at least: 4.4
 Tested up to:      4.4.1


### PR DESCRIPTION
I asked at Slack and they told me to change the readme.txt, since the reference was not working at https://wordpress.org/plugins/rename-wp-login/#related