### PR TITLE
Translation context needed to distinguish terms

### DIFF
--- a/rename-wp-login.php
+++ b/rename-wp-login.php
@@ -177,7 +177,7 @@ if ( defined( 'ABSPATH' ) && ! class_exists( 'Rename_WP_Login' ) ) {
 
 			add_settings_section(
 				'rename-wp-login-section',
-				_x( 'Rename wp-login.php', 'Text string for options-page', 'rename-wp-login' ),
+				_x( 'Rename wp-login.php', 'Text string for settings page', 'rename-wp-login' ),
 				array( $this, 'rwl_section_desc' ),
 				'permalink'
 			);

--- a/rename-wp-login.php
+++ b/rename-wp-login.php
@@ -150,7 +150,7 @@ if ( defined( 'ABSPATH' ) && ! class_exists( 'Rename_WP_Login' ) ) {
 		public function wpmu_options() {
 			$out = '';
 
-			$out .= '<h3>' . __( 'Rename wp-login.php', 'rename-wp-login' ) . '</h3>';
+			$out .= '<h3>' . _x( 'Rename wp-login.php', 'Text string for settings page', 'rename-wp-login' ) . '</h3>';
 			$out .= '<p>' . __( 'This option allows you to set a networkwide default, which can be overridden by individual sites. Simply go to to the site’s permalink settings to change the url.', 'rename-wp-login' ) . '</p>';
 			$out .= '<table class="form-table">';
 				$out .= '<tr valign="top">';
@@ -177,7 +177,7 @@ if ( defined( 'ABSPATH' ) && ! class_exists( 'Rename_WP_Login' ) ) {
 
 			add_settings_section(
 				'rename-wp-login-section',
-				__( 'Rename wp-login.php', 'rename-wp-login' ),
+				_x( 'Rename wp-login.php', 'Text string for options-page', 'rename-wp-login' ),
 				array( $this, 'rwl_section_desc' ),
 				'permalink'
 			);


### PR DESCRIPTION
While translating this plugin I stumbled upon the text string `Replace wp-login.php` which is 

1. the name of the plugin and therefore **shouldn't** be translated (as it would make it difficult to find the plugin under it's translated name)
2. a text string used on the settings page and therefore **should** be translated (as it explains the user what to do in the settings page).

To distinguish between these test strings, I suggest to use WordPress function `_x()` to add some context for translators and give the chance to translate both text strings independently.