### PR TITLE
Enhancement: Make Update Notice dismissible

### DIFF
--- a/rename-wp-login.php
+++ b/rename-wp-login.php
@@ -241,7 +241,7 @@ if ( defined( 'ABSPATH' ) && ! class_exists( 'Rename_WP_Login' ) ) {
 			global $pagenow;
 
 			if ( ! is_network_admin() && $pagenow === 'options-permalink.php' && isset( $_GET['settings-updated'] ) ) {
-				echo '<div class="updated"><p>' . sprintf( __( 'Your login page is now here: %s. Bookmark this page!', 'rename-wp-login' ), '<strong><a href="' . $this->new_login_url() . '">' . $this->new_login_url() . '</a></strong>' ) . '</p></div>';
+				echo '<div class="updated notice is-dismissible"><p>' . sprintf( __( 'Your login page is now here: %s. Bookmark this page!', 'rename-wp-login' ), '<strong><a href="' . $this->new_login_url() . '">' . $this->new_login_url() . '</a></strong>' ) . '</p></div>';
 			}
 		}
 


### PR DESCRIPTION
By adding CSS class `.is-dismissible` user can dismiss the admin notice shown after updating the link to the login form. (Class was added in [WordPress 4.2](https://make.wordpress.org/core/2015/04/23/spinners-and-dismissible-admin-notices-in-4-2/))