### PR TITLE
Add integration and validation tools: TravisCI + CodeClimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,25 @@
+---
+engines:
+  duplication:
+    enabled: true
+    config:
+      languages:
+        - php
+  fixme:
+    enabled: true
+  phpmd:
+    enabled: true
+    config:
+      rulesets: "tests/phpmd.xml"
+  phpcodesniffer:
+    enabled: true
+    config:
+      standard: "Wordpress-Extra"
+ratings:
+  paths:
+  - "**.php"
+exclude_paths:
+- tests/*
+- bin/*
+# Local
+- vendor/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,65 @@
+# This uses newer and faster docker based build system
+sudo: false
+
+language: php
+
+notifications:
+  on_success: never
+  on_failure: change
+
+php:
+  - 7.1
+  - 7.0
+
+env:
+    - WP_VERSION=latest WP_MULTISITE=0
+    - WP_VERSION=latest WP_MULTISITE=1
+
+matrix:
+    allow_failures:
+      - php: 5.2
+      - php: nightly # PHP 7.x
+#     - env: WP_VERSION=bleeding WP_MULTISITE=0
+#     - env: WP_VERSION=bleeding-maintenance WP_MULTISITE=0
+
+    include:
+    - php: nightly
+      env: WP_VERSION=latest WP_MULTISITE=0
+    - php: hhvm
+      env: WP_VERSION=latest WP_MULTISITE=0
+    - php: 5.6
+      env: WP_VERSION=latest WP_MULTISITE=0
+    - php: 5.3
+      env: WP_VERSION=4.4 WP_MULTISITE=0
+    - php: 5.2
+      env: WP_VERSION=latest WP_MULTISITE=0
+    - php: 5.2
+      env: WP_VERSION=4.4 WP_MULTISITE=0
+
+## Cache composer bits
+cache:
+  apt: true
+  directories:
+    - vendor
+    - $HOME/.composer/cache
+
+before_script:
+  - if [[ $TRAVIS_PHP_VERSION != 'hhvm' && $TRAVIS_PHP_VERSION != 'nightly' ]]; then
+      phpenv config-rm xdebug.ini;
+    fi
+
+# Install composer packages before trying to activate themes or plugins
+  - if [[ $TRAVIS_PHP_VERSION != 5.2 ]]; then
+      composer self-update;
+      composer install --no-interaction --prefer-source;
+    fi
+
+  - bash bin/install-wp-tests.sh test root '' localhost $WP_VERSION
+
+script:
+# Use phpunit from composer
+  - if [[ $TRAVIS_PHP_VERSION != 5.2 ]]; then
+      vendor/bin/phpunit;
+    else
+      phpunit;
+    fi

--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# Rename wp-login.php
+
+[![WordPress Plugin version](https://img.shields.io/wordpress/plugin/v/rename-wp-login.svg?style=flat)](https://wordpress.org/plugins/rename-wp-login/)
+[![WordPress Plugin WP tested version](https://img.shields.io/wordpress/v/rename-wp-login.svg?style=flat)](https://wordpress.org/plugins/rename-wp-login/)
+[![WordPress Plugin downloads](https://img.shields.io/wordpress/plugin/dt/rename-wp-login.svg?style=flat)](https://wordpress.org/plugins/rename-wp-login/)
+[![WordPress Plugin rating](https://img.shields.io/wordpress/plugin/r/rename-wp-login.svg?style=flat)](https://wordpress.org/plugins/rename-wp-login/)
+[![License](https://img.shields.io/badge/license-GPL--2.0%2B-green.svg)](https://github.com/iseulde/rename-wp-login/blob/master/license.txt)
+[![Travis](https://secure.travis-ci.org/iseulde/rename-wp-login.png?branch=master)](http://travis-ci.org/iseulde/rename-wp-login)
+[![Code Climate](https://codeclimate.com/github/iseulde/rename-wp-login/badges/gpa.svg)](https://codeclimate.com/github/iseulde/rename-wp-login)
+
+*Rename wp-login.php* is a very light plugin that lets you easily and safely change wp-login.php to anything you want. It doesn’t literally rename or change files in core, nor does it add rewrite rules. It simply intercepts page requests and works on any WordPress website. The wp-admin directory and wp-login.php page become inaccessible, so you should bookmark or remember the url. Deactivating this plugin brings your site back exactly to the state it was before.
+
+### Compatibility
+
+All login related things such as the registration form, lost password form, login widget and expired sessions just keep working.
+
+It’s also compatible with any plugin that hooks in the login form, including
+
+* BuddyPress,
+* bbPress,
+* Limit Login Attempts,
+* and User Switching.
+
+Obviously it doesn’t work with plugins that *hardcoded* wp-login.php.
+
+Works with multisite, but not tested with subdomains. Activating it for a network allows you to set a networkwide default. Individual sites can still rename their login page to something else.
+
+If you’re using a **page caching plugin** you should add the slug of the new login url to the list of pages not to cache.
+
+If you wish, you can block wp-login.php with `.htaccess` from now on.
+
+## Installation
+
+1. Go to Plugins › Add New.
+2. Search for *Rename wp-login.php*.
+3. Look for this plugin, download and activate it.
+4. The page will redirect you to the settings. Rename wp-login.php there.
+5. You can change this option any time you want, just go back to Settings › Permalinks › Rename wp-login.php.
+
+## I forgot my login url!
+
+Either go to your MySQL database and look for the value of `rwl_page` in the options table, or remove the `rename-wp-login` folder from your `plugins` folder, log in through wp-login.php and reinstall the plugin.
+
+On a multisite install the `rwl_page` option will be in the sitemeta table, if there is no such option in the options table.

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+
+if [ $# -lt 3 ]; then
+	echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version] [force download] [skip-database-creation]"
+	exit 1
+fi
+
+DB_NAME=$1
+DB_USER=$2
+DB_PASS=$3
+DB_HOST=${4-localhost}
+WP_VERSION=${5-latest}
+FORCE=${6-false}
+SKIP_DB_CREATE=${7-false}
+
+WP_TESTS_DIR=${WP_TESTS_DIR-/tmp/wordpress-tests-lib}
+WP_CORE_DIR=${WP_CORE_DIR-/tmp/wordpress/}
+
+# Placeholder for download agent
+# @todo replace back to wget everywhere in this file
+download() {
+
+    if [ `which curl` ]; then
+        curl -s "$1" > "$2";
+	elif [ `which wget` ]; then
+        wget -nv -O "$2" "$1"
+	fi
+
+}
+
+# Detect version tag
+# Format: N.N.N
+if [[ $WP_VERSION =~ [0-9]+\.[0-9]+(\.[0-9]+)? ]]; then
+	WP_TESTS_TAG="tags/$WP_VERSION"
+elif [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+	WP_TESTS_TAG="trunk"
+else
+	# http serves a single offer, whereas https serves multiple. we only want one
+	download http://api.wordpress.org/core/version-check/1.7/ /tmp/wp-latest.json
+	grep '[0-9]+\.[0-9]+(\.[0-9]+)?' /tmp/wp-latest.json
+	LATEST_VERSION=$(grep -o '"version":"[^"]*' /tmp/wp-latest.json | sed 's/"version":"//')
+
+	if [[ -z "$LATEST_VERSION" ]]; then
+		echo "Latest WordPress version could not be found"
+		exit 1
+	fi
+
+	WP_TESTS_TAG="tags/$LATEST_VERSION"
+fi
+
+if [[ $WP_TESTS_TAG == *"beta"* ]]
+then
+	WP_TESTS_TAG="trunk"
+fi
+
+set -ex
+
+install_wp() {
+
+	echo "Installing WordPress for Unit Tests"
+
+	if [[ $FORCE == 'true' || -z TRAVIS_JOB_ID ]]; then
+		echo "Removing existing core WordPress directory"
+
+		rm -Rf $WP_CORE_DIR
+	fi
+
+	if [ -d $WP_CORE_DIR ]; then
+		return;
+	fi
+
+	echo "Downloading WordPress"
+
+	mkdir -p $WP_CORE_DIR
+
+	if [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+		mkdir -p /tmp/wordpress-nightly
+		download https://wordpress.org/nightly-builds/wordpress-latest.zip  /tmp/wordpress-nightly/wordpress-nightly.zip
+		unzip -q /tmp/wordpress-nightly/wordpress-nightly.zip -d /tmp/wordpress-nightly/
+		mv /tmp/wordpress-nightly/wordpress/* $WP_CORE_DIR
+	else
+		if [ $WP_VERSION == 'latest' ]; then
+			local ARCHIVE_NAME='latest'
+		else
+			local ARCHIVE_NAME="wordpress-$WP_VERSION"
+		fi
+
+		download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  /tmp/wordpress.tar.gz
+		tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C $WP_CORE_DIR
+	fi
+
+	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
+
+	echo "WordPress installed"
+
+}
+
+install_test_suite() {
+
+	echo "Installing Tests Suite for Unit Tests"
+
+	if [[ $FORCE == 'true' || -z TRAVIS_JOB_ID ]]; then
+		echo "Removing existing Tests Suite directory"
+
+		rm -Rf $WP_TESTS_DIR
+	fi
+
+	# portable in-place argument for both GNU sed and Mac OS X sed
+	if [[ $(uname -s) == 'Darwin' ]]; then
+		local ioption='-i .bak'
+	else
+		local ioption='-i'
+	fi
+
+	# set up testing suite if it doesn't yet exist
+	if [ ! -d $WP_TESTS_DIR ]; then
+		echo "Downloading Tests Suite"
+
+		# set up testing suite
+		mkdir -p $WP_TESTS_DIR
+		svn export --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes $WP_TESTS_DIR/includes
+		svn export --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data $WP_TESTS_DIR/data
+	fi
+
+	cd $WP_TESTS_DIR
+
+	if [ ! -f wp-tests-config.php ]; then
+		download https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php "$WP_TESTS_DIR"/wp-tests-config.php
+		# remove all forward slashes in the end
+		WP_CORE_DIR=$(echo $WP_CORE_DIR | sed "s:/\+$::")
+		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR/':" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s|localhost|${DB_HOST}|" "$WP_TESTS_DIR"/wp-tests-config.php
+	fi
+
+	echo "Tests Suite installed"
+
+}
+
+install_db() {
+
+	if [ ${SKIP_DB_CREATE} = "true" ]; then
+		return 0
+	fi
+
+	echo "Setting up Database for Unit Tests"
+
+	# parse DB_HOST for port or socket references
+	local PARTS=(${DB_HOST//\:/ })
+	local DB_HOSTNAME=${PARTS[0]};
+	local DB_SOCK_OR_PORT=${PARTS[1]};
+	local EXTRA=""
+
+	if ! [ -z $DB_HOSTNAME ] ; then
+		if [ $(echo $DB_SOCK_OR_PORT | grep -e '^[0-9]\{1,\}$') ]; then
+			EXTRA=" --host=$DB_HOSTNAME --port=$DB_SOCK_OR_PORT --protocol=tcp"
+		elif ! [ -z $DB_SOCK_OR_PORT ] ; then
+			EXTRA=" --socket=$DB_SOCK_OR_PORT"
+		elif ! [ -z $DB_HOSTNAME ] ; then
+			EXTRA=" --host=$DB_HOSTNAME --protocol=tcp"
+		fi
+	fi
+
+	if [[ $FORCE == 'true' || -z TRAVIS_JOB_ID ]]; then
+		echo "Removing existing Database"
+
+		# drop database
+		mysql --user="$DB_USER" --password="$DB_PASS"$EXTRA -e "DROP DATABASE IF EXISTS $DB_NAME"
+	fi
+
+	echo "Creating Database"
+
+	# create database
+	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
+
+	echo "Database set up"
+
+}
+
+install_wp
+install_test_suite
+install_db

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,19 @@
+{
+	"name": "iseulde/rename-wp-login",
+	"type": "wordpress-plugin",
+	"description": "Change wp-login.php to anything you want.",
+	"keywords": [],
+	"homepage": "https://github.com/iseulde/rename-wp-login",
+	"license": "GPL-2.0+",
+	"authors": [],
+	"require": {
+		"composer/installers": "1.2.*",
+		"php": ">=5.2.4"
+	},
+	"require-dev": {
+		"phpunit/phpunit": "4.8.*",
+	},
+	"extra": {
+		"installer-name": "rename-wp-login"
+	}
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,14 @@
+<phpunit
+	bootstrap="tests/bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+	>
+	<testsuites>
+		<testsuite>
+			<directory prefix="test-" suffix=".php">./tests/</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@
 Contributors:      iseulde, ivanrf
 Tags:              rename, login, wp-login, wp-login.php, custom login url
 Requires at least: 4.4
-Tested up to:      4.4.1
+Tested up to:      4.7
 Stable tag:        2.5.5
 License:           GPL-2.0+
 

--- a/rename-wp-login.php
+++ b/rename-wp-login.php
@@ -158,7 +158,7 @@ if ( defined( 'ABSPATH' ) && ! class_exists( 'Rename_WP_Login' ) ) {
 			if (
 				( $rwl_page = sanitize_title_with_dashes( $_POST['rwl_page'] ) ) &&
 				strpos( $rwl_page, 'wp-login' ) === false &&
-				! in_array( $rwl_page, $this->forbidden_slugs() )
+				! in_array( $rwl_page, $this->forbidden_slugs(), true )
 			) {
 				update_site_option( 'rwl_page', $rwl_page );
 			}
@@ -186,7 +186,7 @@ if ( defined( 'ABSPATH' ) && ! class_exists( 'Rename_WP_Login' ) ) {
 				if (
 					( $rwl_page = sanitize_title_with_dashes( $_POST['rwl_page'] ) ) &&
 					strpos( $rwl_page, 'wp-login' ) === false &&
-					! in_array( $rwl_page, $this->forbidden_slugs() )
+					! in_array( $rwl_page, $this->forbidden_slugs(), true )
 				) {
 					if ( is_multisite() && get_site_option( 'rwl_page', 'login' ) === $rwl_page ) {
 						delete_option( 'rwl_page' );

--- a/rename-wp-login.php
+++ b/rename-wp-login.php
@@ -276,7 +276,7 @@ if ( defined( 'ABSPATH' ) && ! class_exists( 'Rename_WP_Login' ) ) {
 				wp_die( __( 'This feature is not enabled.', 'rename-wp-login' ), '', array( 'response' => 403 ) );
 			}
 
-			$request = parse_url( $_SERVER['REQUEST_URI'] );
+			$request = wp_parse_url( $_SERVER['REQUEST_URI'] );
 
 			if ( (
 					strpos( $_SERVER['REQUEST_URI'], 'wp-login.php' ) !== false ||
@@ -304,7 +304,7 @@ if ( defined( 'ABSPATH' ) && ! class_exists( 'Rename_WP_Login' ) ) {
 				wp_die( __( 'You must log in to access the admin area.', 'rename-wp-login' ), '', array( 'response' => 403 ) );
 			}
 
-			$request = parse_url( $_SERVER['REQUEST_URI'] );
+			$request = wp_parse_url( $_SERVER['REQUEST_URI'] );
 
 			if (
 				'wp-login.php' === $pagenow &&
@@ -317,7 +317,7 @@ if ( defined( 'ABSPATH' ) && ! class_exists( 'Rename_WP_Login' ) ) {
 				if (
 					( $referer = wp_get_referer() ) &&
 					strpos( $referer, 'wp-activate.php' ) !== false &&
-					( $referer = parse_url( $referer ) ) &&
+					( $referer = wp_parse_url( $referer ) ) &&
 					! empty( $referer['query'] )
 				) {
 					parse_str( $referer['query'], $referer );

--- a/rename-wp-login.php
+++ b/rename-wp-login.php
@@ -147,7 +147,7 @@ if ( defined( 'ABSPATH' ) && ! class_exists( 'Rename_WP_Login' ) ) {
 							__( 'Networkwide default', 'rename-wp-login' ) .
 						'</th>' .
 						'<td>' .
-							'<input id="rwl-page-input" type="text" name="rwl_page" value="' . get_site_option( 'rwl_page', 'login' )  . '">' .
+							'<input id="rwl-page-input" type="text" name="rwl_page" value="' . get_site_option( 'rwl_page', 'login' ) . '">' .
 						'</td>' .
 					'</tr>' .
 				'</table>'
@@ -229,9 +229,9 @@ if ( defined( 'ABSPATH' ) && ! class_exists( 'Rename_WP_Login' ) ) {
 
 		public function rwl_page_input() {
 			if ( get_option( 'permalink_structure' ) ) {
-				echo '<code>' . trailingslashit( home_url() ) . '</code> <input id="rwl-page-input" type="text" name="rwl_page" value="' . $this->new_login_slug()  . '">' . ( $this->use_trailing_slashes() ? ' <code>/</code>' : '' );
+				echo '<code>' . trailingslashit( home_url() ) . '</code> <input id="rwl-page-input" type="text" name="rwl_page" value="' . $this->new_login_slug() . '">' . ( $this->use_trailing_slashes() ? ' <code>/</code>' : '' );
 			} else {
-				echo '<code>' . trailingslashit( home_url() ) . '?</code> <input id="rwl-page-input" type="text" name="rwl_page" value="' . $this->new_login_slug()  . '">';
+				echo '<code>' . trailingslashit( home_url() ) . '?</code> <input id="rwl-page-input" type="text" name="rwl_page" value="' . $this->new_login_slug() . '">';
 			}
 		}
 

--- a/rename-wp-login.php
+++ b/rename-wp-login.php
@@ -216,6 +216,7 @@ if ( defined( 'ABSPATH' ) && ! class_exists( 'Rename_WP_Login' ) ) {
 				echo (
 					'<p>' .
 						sprintf(
+							// Translators: %s stands for a link element: "Network Settings".
 							__( 'To set a networkwide default, go to %s.', 'rename-wp-login' ),
 							'<a href="' . esc_url( network_admin_url( 'settings.php#rwl-page-input' ) ) . '">' .
 								__( 'Network Settings', 'rename-wp-login' ) .
@@ -238,6 +239,7 @@ if ( defined( 'ABSPATH' ) && ! class_exists( 'Rename_WP_Login' ) ) {
 			global $pagenow;
 
 			if ( ! is_network_admin() && $pagenow === 'options-permalink.php' && isset( $_GET['settings-updated'] ) ) {
+				// Translators: %s stands for a link element.
 				echo '<div class="notice notice-success is-dismissible"><p>' . sprintf( __( 'Your login page is now here: %s. Bookmark this page!', 'rename-wp-login' ), '<strong><a href="' . $this->new_login_url() . '">' . $this->new_login_url() . '</a></strong>' ) . '</p></div>';
 			}
 		}

--- a/rename-wp-login.php
+++ b/rename-wp-login.php
@@ -182,13 +182,13 @@ if ( defined( 'ABSPATH' ) && ! class_exists( 'Rename_WP_Login' ) ) {
 				'rename-wp-login-section'
 			);
 
-			if ( isset( $_POST['rwl_page'] ) && $pagenow === 'options-permalink.php' ) {
+			if ( isset( $_POST['rwl_page'] ) && 'options-permalink.php' === $pagenow ) {
 				if (
 					( $rwl_page = sanitize_title_with_dashes( $_POST['rwl_page'] ) ) &&
 					strpos( $rwl_page, 'wp-login' ) === false &&
 					! in_array( $rwl_page, $this->forbidden_slugs() )
 				) {
-					if ( is_multisite() && $rwl_page === get_site_option( 'rwl_page', 'login' ) ) {
+					if ( is_multisite() && get_site_option( 'rwl_page', 'login' ) === $rwl_page ) {
 						delete_option( 'rwl_page' );
 					} else {
 						update_option( 'rwl_page', $rwl_page );
@@ -305,7 +305,7 @@ if ( defined( 'ABSPATH' ) && ! class_exists( 'Rename_WP_Login' ) ) {
 			$request = parse_url( $_SERVER['REQUEST_URI'] );
 
 			if (
-				$pagenow === 'wp-login.php' &&
+				'wp-login.php' === $pagenow &&
 				$request['path'] !== $this->user_trailingslashit( $request['path'] ) &&
 				get_option( 'permalink_structure' )
 			) {
@@ -333,7 +333,7 @@ if ( defined( 'ABSPATH' ) && ! class_exists( 'Rename_WP_Login' ) ) {
 				}
 
 				$this->wp_template_loader();
-			} elseif ( $pagenow === 'wp-login.php' ) {
+			} elseif ( 'wp-login.php' === $pagenow ) {
 				global $error, $interim_login, $action, $user_login;
 
 				@require_once ABSPATH . 'wp-login.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,40 @@
+<?php
+
+if ( function_exists( 'xdebug_disable' ) ) {
+	xdebug_disable();
+}
+// PHP < 5.3
+if ( ! defined( '__DIR__' ) ) {
+	define( '__DIR__', dirname( __FILE__ ) );
+}
+
+// Error reporting
+error_reporting( E_ALL & ~E_DEPRECATED & ~E_STRICT );
+
+$_tests_dir = getenv( 'WP_TESTS_DIR' );
+if ( ! $_tests_dir ) {
+	$_tests_dir = '/tmp/wordpress-tests-lib';
+}
+
+define( 'TEST_RWL_PLUGIN_NAME'   , 'rename-wp-login.php' );
+define( 'TEST_RWL_PLUGIN_FOLDER' , basename( dirname( __DIR__ ) ) );
+define( 'TEST_RWL_PLUGIN_PATH'   , TEST_RWL_PLUGIN_FOLDER . '/' . TEST_RWL_PLUGIN_NAME );
+
+
+// Activates this plugin in WordPress so it can be tested.
+$GLOBALS['wp_tests_options'] = array(
+  'active_plugins' => array( TEST_RWL_PLUGIN_PATH ),
+);
+
+require_once $_tests_dir . '/includes/functions.php';
+
+function _manually_load_plugin() {
+	require dirname( __DIR__ ) . '/' . TEST_RWL_PLUGIN_NAME;
+}
+tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
+
+require $_tests_dir . '/includes/bootstrap.php';
+
+echo 'Installing Rename wp-login.php' . PHP_EOL;
+
+activate_plugin( TEST_RWL_PLUGIN_PATH );

--- a/tests/phpcs.xml
+++ b/tests/phpcs.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<ruleset name="Rename wp-login.php">
+    <description>Customization for PHP Code Sniffer based on the WordPress Extra ruleset</description>
+
+    <exclude-pattern>tests/*</exclude-pattern>
+    <exclude-pattern>bin/*</exclude-pattern>
+
+    <arg name="extensions" value="php" />
+
+    <rule ref="WordPress-Extra" />
+</ruleset>

--- a/tests/phpmd.xml
+++ b/tests/phpmd.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<ruleset name="WordPress Rename wp-login.php"
+         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
+         xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
+	<description>Plugin Standards</description>
+
+	<!-- Design -->
+	<rule ref="rulesets/design.xml" />
+
+	<!-- CleanCode -->
+	<rule ref="rulesets/cleancode.xml" />
+
+	<!-- CodeSize -->
+	<rule ref="rulesets/codesize.xml" />
+
+	<!-- Naming -->
+	<rule ref="rulesets/naming.xml" />
+
+</ruleset>

--- a/tests/test-plugin.php
+++ b/tests/test-plugin.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Rename wp-login.php - Unit tests
+ */
+
+class Rename_WP_Login_UnitTest extends WP_UnitTestCase {
+
+	/**
+	 * Check that activation doesn't break.
+	 */
+	function test_vaa_activated() {
+		$this->assertTrue( is_plugin_active( TEST_RWL_PLUGIN_PATH ) );
+	}
+}


### PR DESCRIPTION
I noticed this plugin isn't using any CI tools yet so could be a good way to check everything with different versions etc. before deploying on the WP repository.
This PR will add all the required files to integrate with TravisCI and CodeClimate (both free tools for open source projects). You just need to create an acount on both with your GitHub login and enable it for this repository once the PR is merged.

I've also updated the "Tested up to" version to WP 4.7.x.

## Checks done with TravisCI:
- PHP 7.1 -> Latest WP verson, both single and multisite
- PHP 7.0 -> Latest WP verson, both single and multisite
- PHP 5.6 + Latest WP verson (single installation)
- PHP hhvm + WP 4.4 (single installation)
- PHP 5.3 + WP 4.4 (single installation)

**Allowed failures:**
- PHP 5.2 + Latest WP verson (single installation)
- PHP 5.2 + WP 4.4 (single installation)
- PHP hhvm + WP 4.4 (single installation)

## Checks done with CodeClimate
I haven't customized this yet.  
Some checks (like Nonces) could be disabled in this case).

**PHP Mess Detector**
- Design (all checks)
- CleanCode (all checks)
- CodeSize (all checks)
- Naming (all checks)

**PHP Code Sniffer**
WordPress-Extra code standards
https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards

## TODO:
- [ ] Create PHP Unit Tests. Currently it only checks of the plugin activation works.
- [ ] Fix other CodeClimate issues that come up (probably a second PR since it a first scan will need to be triggered from the plugin master branch).